### PR TITLE
Add book recommendations for PL

### DIFF
--- a/docs/好书推荐.md
+++ b/docs/好书推荐.md
@@ -16,8 +16,10 @@
 - [My First Language Frontend with LLVM Tutorial](https://llvm.org/docs/tutorial/MyFirstLanguageFrontend/index.html)
 - Compilers: Principles, Techniques, and Tools (Dragon Book)
 ## 计算机语言（PL）
-- Essentials of Programming Languages (EOPL)
-- [Types and Programming Languages (TAPL)](https://www.cis.upenn.edu/~bcpierce/tapl/)
+- [Essentials of Programming Languages (EOPL)](https://eopl3.com/)
+- [Types and Programming Languages (TAPL)](https://www.cis.upenn.edu/~bcpierce/tapl/) ([北大相关课程](https://xiongyingfei.github.io/DPPL/2021/main.htm))
+- [Practical Foundations for Programming Languages (PFPL)](https://www.cs.cmu.edu/~rwh/pfpl.html)
+- [Software Foundations (SF)](https://softwarefoundations.cis.upenn.edu/) ([北大相关课程](https://xiongyingfei.github.io/SF/2021/))
 ## 体系结构
 - Computer Architecture: A Quantitative Approach 5th Edition
 ## 分布式系统


### PR DESCRIPTION
- Added a link to EOPL's official site.
- Added two more books for PL (PFPL & SF).
- Associated two books (TAPL & SF) with related PKU courses.